### PR TITLE
Fix typos. Reduced the number of generations.

### DIFF
--- a/GRPO_Qwen_0_5_Instruct.ipynb
+++ b/GRPO_Qwen_0_5_Instruct.ipynb
@@ -49,7 +49,7 @@
         "\n",
         "In this tutorial, we demonstrate how to build a reinforcement learning (RL) pipeline using the GRPO (Group Relative Policy Optimization) method to finetune a language model for math, logic, and coding tasks. These are tasks for which there exist a unique correct answer that can be easily verified with the ground truth answer using a simple string comparison.\n",
         "\n",
-        "GRPO was used the DeepSeek R1 and R1-Zero models. You will find a detailed overview of GRPO and how R1 and R1-Zero were trained in [this article](https://thelmbook.com/articles/#!./DeepSeek-R1.md).\n",
+        "GRPO was used in the DeepSeek R1 and R1-Zero models. You will find a detailed overview of GRPO and how R1 and R1-Zero were trained in [this article](https://thelmbook.com/articles/#!./DeepSeek-R1.md).\n",
         "\n",
         "Our objective of this tutorial is to transform a generalist language model into a math problem solver. We integrate several popular libraries and tools, including:\n",
         "\n",
@@ -308,7 +308,7 @@
         "set_random_seed(42)\n",
         "\n",
         "import os\n",
-        "os.environ[\"WANDB_API_KEY\"] = \"PUT_YOUR_KET_HERE\"\n",
+        "os.environ[\"WANDB_API_KEY\"] = \"PUT_YOUR_KEY_HERE\"\n",
         "os.environ[\"WANDB_PROJECT\"] = \"GRPO-Qwen-0.5-Instruct\"\n",
         "\n",
         "!wandb login\n",
@@ -427,7 +427,7 @@
         "\n",
         "## Part 3: Dataset Preparation\n",
         "\n",
-        "In this part we prepare the GSM8K dataset for training. GSM8K is a dataset of 8.5K high quality linguistically diverse grade school math word problems created by human problem writers. We will use the examples from this dataset to train our model in the reinforcement learning (RL) paradigm: the model will generate several sample probelem solutions, we will compare these solutions to the ground truth number from a GSM8K example and, if there's a match, we will provide a high reward to the RL algorithm (GRPO) which will update the model's weights so that the chance of getting the high reward next time is increased.\n",
+        "In this part we prepare the GSM8K dataset for training. GSM8K is a dataset of 8.5K high quality linguistically diverse grade school math word problems created by human problem writers. We will use the examples from this dataset to train our model in the reinforcement learning (RL) paradigm: the model will generate several sample problem solutions, we will compare these solutions to the ground truth number from a GSM8K example and, if there's a match, we will provide a high reward to the RL algorithm (GRPO) which will update the model's weights so that the chance of getting the high reward next time is increased.\n",
         "\n",
         "We first load the dataset from Hugging Face and then format each example to include a system prompt and a user prompt. We also extract the expected answer from the dataset. Two helper functions are defined here:\n",
         "\n",
@@ -503,7 +503,7 @@
         "id": "gL2066bAOBtD"
       },
       "source": [
-        "The problem with finetuning a model as small as Qwen-0.5B-Instruct is that it's too small to consistently follow out instruction given in the system proimpt to generate the `<reasoning>` and `<answer>` tags. Without these tags, we cannot generate the reward for giving the right answer. We need to help the model a little bit in the beginning. For this, I generated a dataset of Chain-of-Thought (CoT) sequences for some of the `gsm8k` examples. We will use 500 of them to finetune the model in a supervised (SFT) way to teach it using `<reasoning>` and `<answer>` tags before we apply the reinforcement learning.\n",
+        "The problem with finetuning a model as small as Qwen-0.5B-Instruct is that it's too small to consistently follow out instruction given in the system prompt to generate the `<reasoning>` and `<answer>` tags. Without these tags, we cannot generate the reward for giving the right answer. We need to help the model a little bit in the beginning. For this, I generated a dataset of Chain-of-Thought (CoT) sequences for some of the `gsm8k` examples. We will use 500 of them to finetune the model in a supervised (SFT) way to teach it using `<reasoning>` and `<answer>` tags before we apply the reinforcement learning.\n",
         "\n",
         "To achieve that, we add functions to download and extract the CoT file and to prepare an SFT dataset. In this case, we generate SFT examples by reading CoT outputs from the archive. The filename for each example is determined by the SHA-256 hash of the corresponding `gsm8k` question.\n",
         "\n",
@@ -24080,7 +24080,7 @@
         "        logging_steps=5,\n",
         "        eval_steps=50,\n",
         "        bf16=True,\n",
-        "        per_device_train_batch_size=4,\n",
+        "        per_device_train_batch_size=8,\n",
         "        gradient_accumulation_steps=4,\n",
         "        max_steps=500,\n",
         "        num_train_epochs=1,\n",
@@ -24230,7 +24230,7 @@
         "  For every prompt in the training data, the trainer will generate 8 different completions. These multiple generations are used to compute a relative advantage (or reward signal) that guides the RL update. We use 8 here to save time, but the larger the sample the better are the statistics used by GRPO to update the model's parameters.\n",
         "\n",
         "- **max_completion_length=300**  \n",
-        "  When generating completions (the “response” portion of the sequence), the generation is capped at 300 tokens. This limits the length of the outputs produced by the model during the RL phase. We used the maximum lenght of 300 because longer outputs would make the training on one GPU too slow. In reality, teh generated chains of thoughts, to be useful, are usually much longer.\n",
+        "  When generating completions (the “response” portion of the sequence), the generation is capped at 300 tokens. This limits the length of the outputs produced by the model during the RL phase. We used the maximum length of 300 because longer outputs would make the training on one GPU too slow. In reality, the generated chains of thoughts, to be useful, are usually much longer.\n",
         "\n",
         "- **report_to=[\"wandb\"]**  \n",
         "  During RL training, metrics are reported to WandB (Weights & Biases). This allows tracking of performance and other metrics via the WandB dashboard.\n",
@@ -24255,7 +24255,7 @@
     {
       "cell_type": "markdown",
       "source": [
-        "The above graphs show that the model learns: the average reward for using `<reasoning>` and `<answer>` almost reached the maximum of 0.8. The average reward for putting the correct answers into the `<answer>` tag plateaued around 0.6, which is low, compared to the maximum of 2.0. This can be explained by the small size of our model and a very low allowed response length we used (300). As you can see friom the last plot, the model learned to play safe and to generate responses of about 200 tokens so that it gets the formatting rewards as frequently as possible, but this plays against getting the correct answer.\n",
+        "The above graphs show that the model learns: the average reward for using `<reasoning>` and `<answer>` almost reached the maximum of 0.8. The average reward for putting the correct answers into the `<answer>` tag plateaued around 0.6, which is low, compared to the maximum of 2.0. This can be explained by the small size of our model and a very low allowed response length we used (300). As you can see from the last plot, the model learned to play safe and to generate responses of about 200 tokens so that it gets the formatting rewards as frequently as possible, but this plays against getting the correct answer.\n",
         "\n",
         "Using a larger model and allowing for much longer generations will increase the model's ability to learn to generate the correct answers more often."
       ],


### PR DESCRIPTION
I fixed 4 typos and reduced the number of generations (num_generations) from 8 to 4 to avoid the error seen in the last screenshot.

![image](https://github.com/user-attachments/assets/256dcc04-8235-45af-9017-768965ab5e73)
![image](https://github.com/user-attachments/assets/d3d81832-b8ba-480e-ae30-0251e82dca33)
![image](https://github.com/user-attachments/assets/31c67f47-16a7-443b-b487-c90391d7ed1d)
![image](https://github.com/user-attachments/assets/08afee8b-e026-475b-a7a6-8f30e67b5c3e)
![image](https://github.com/user-attachments/assets/06042c51-5225-49ab-ab4b-cfff62dbfb4e)
